### PR TITLE
Migrate rendering from Canvas 2D API to PixiJS

### DIFF
--- a/environment.js
+++ b/environment.js
@@ -30,7 +30,12 @@ export function generateClouds(cloudLayersArrayRef) { // Modifies the passed arr
     } 
 }
 
-export function drawClouds(mainCtx, camX_m, camY_m, ppm, spacecraftAltitudeAGL, cloudLayersArray) { 
+export function drawClouds(container, camX_m, camY_m, ppm, spacecraftAltitudeAGL, cloudLayersArray) { 
+    const canvasWidth = container.parent.view.width;
+    const canvasHeight = container.parent.view.height;
+    const viewCenterX_px = canvasWidth / 2;
+    const viewCenterY_px = canvasHeight / 2;
+
     cloudLayersArray.forEach(layer => { 
         const parallaxOffsetX = camX_m * (1 - layer.parallaxFactor); 
         const parallaxOffsetY = camY_m * (1 - layer.parallaxFactor); 
@@ -40,18 +45,29 @@ export function drawClouds(mainCtx, camX_m, camY_m, ppm, spacecraftAltitudeAGL, 
                 overallAlpha *= Math.max(0, 1 - (spacecraftAltitudeAGL - (MAX_CLOUD_ALTITUDE_M + 10000)) / 50000); 
             } 
             if (overallAlpha <= 0.01) return; 
+
+            const cloudPuffColor = 0xEBEBFA; // rgba(235, 235, 250)
+
             cloud.puffs.forEach(puff => { 
                 const puffWorldX = cloud.x_m + puff.dx_m; 
                 const puffWorldY = cloud.y_m + puff.dy_m; 
                 const viewX_px = (puffWorldX - (camX_m - parallaxOffsetX)) * ppm; 
                 const viewY_px = (puffWorldY - (camY_m - parallaxOffsetY)) * ppm; 
                 const radius_px = Math.max(1, puff.r_m * ppm ); 
-                const screenX_px = mainCtx.canvas.width / 2 + viewX_px; 
-                const screenY_px = mainCtx.canvas.height / 2 - viewY_px; 
-                if (screenX_px + radius_px < 0 || screenX_px - radius_px > mainCtx.canvas.width || 
-                    screenY_px + radius_px < 0 || screenY_px - radius_px > mainCtx.canvas.height) return; 
-                mainCtx.fillStyle = `rgba(235, 235, 250, ${overallAlpha.toFixed(2)})`; 
-                mainCtx.beginPath(); mainCtx.arc(screenX_px, screenY_px, radius_px, 0, 2 * Math.PI); mainCtx.fill(); 
+                
+                const screenX_px = viewCenterX_px + viewX_px; 
+                const screenY_px = viewCenterY_px - viewY_px; // Correcting for Pixi's Y-down system
+
+                if (screenX_px + radius_px < 0 || screenX_px - radius_px > canvasWidth || 
+                    screenY_px + radius_px < 0 || screenY_px - radius_px > canvasHeight) return; 
+                
+                const puffGraphic = new PIXI.Graphics();
+                puffGraphic.beginFill(cloudPuffColor, overallAlpha);
+                puffGraphic.drawCircle(0, 0, radius_px);
+                puffGraphic.endFill();
+                puffGraphic.x = screenX_px;
+                puffGraphic.y = screenY_px;
+                container.addChild(puffGraphic);
             }); 
         }); 
     }); 
@@ -79,133 +95,184 @@ export function generateSurfaceFeatures(surfaceFeaturesArrayRef) {
     surfaceFeaturesArrayRef.sort((a, b) => a.angle - b.angle); 
 }
 
-export function drawSurfaceFeatures(mainCtx, camX_m, camY_m, ppm, surfaceFeaturesArray) { 
-    if (ppm < SURFACE_FEATURE_VISIBILITY_PPM) return;  
-    const viewAngleWidth = (mainCtx.canvas.width / ppm) / planet.radius_m * 1.5; 
-    const cameraAngle = Math.atan2(camX_m, camY_m); 
-    surfaceFeaturesArray.forEach(feature => { 
-        let angleDiff = Math.abs(feature.angle - cameraAngle); 
-        if (angleDiff > Math.PI) angleDiff = 2 * Math.PI - angleDiff;  
-        if (angleDiff > viewAngleWidth / 2) return; 
-        const featureBaseX_m = planet.radius_m * Math.sin(feature.angle); 
-        const featureBaseY_m = planet.radius_m * Math.cos(feature.angle); 
-        const viewX_px = (featureBaseX_m - camX_m) * ppm; 
-        const viewY_px = (featureBaseY_m - camY_m) * ppm; 
-        const screenX_px = mainCtx.canvas.width / 2 + viewX_px; 
-        const screenY_px = mainCtx.canvas.height / 2 - viewY_px;  
-        const height_px = feature.height_m * ppm; 
-        const base_px = feature.baseWidth_m * ppm; 
-        if (height_px < 0.5 && base_px < 0.5) return;  
-        mainCtx.save(); 
-        mainCtx.translate(screenX_px, screenY_px); 
-        mainCtx.rotate(feature.angle); 
-        mainCtx.fillStyle = feature.color; 
-        if (feature.type === 'mountain') { 
-            if (base_px > 0.5 && height_px > 0.5) { 
-                mainCtx.beginPath(); mainCtx.moveTo(0, 0); 
-                mainCtx.lineTo(-base_px / 2, -height_px); 
-                mainCtx.lineTo(base_px / 2, -height_px); 
-                mainCtx.closePath(); mainCtx.fill(); 
-            } 
-        } else { 
-            if (base_px > 0.2 && height_px > 0.5) { 
-                const trunkHeight_px = height_px * 0.4; 
-                const foliageRadius_px = height_px * 0.6; 
-                mainCtx.fillRect(-base_px / 2, -trunkHeight_px, base_px, trunkHeight_px); 
-                mainCtx.beginPath(); 
-                mainCtx.arc(0, -trunkHeight_px - foliageRadius_px * 0.6, foliageRadius_px, 0, 2 * Math.PI); 
-                mainCtx.fill(); 
-            } 
-        } 
-        mainCtx.restore(); 
-    }); 
+export function drawSurfaceFeatures(container, camX_m, camY_m, ppm, surfaceFeaturesArray) {
+    if (ppm < SURFACE_FEATURE_VISIBILITY_PPM) return;
+
+    const canvasWidth = container.parent.view.width;
+    const canvasHeight = container.parent.view.height;
+    const viewCenterX_px = canvasWidth / 2;
+    const viewCenterY_px = canvasHeight / 2;
+
+    const viewAngleWidth = (canvasWidth / ppm) / planet.radius_m * 1.5;
+    const cameraAngle = Math.atan2(camX_m, camY_m);
+
+    surfaceFeaturesArray.forEach(feature => {
+        let angleDiff = Math.abs(feature.angle - cameraAngle);
+        if (angleDiff > Math.PI) angleDiff = 2 * Math.PI - angleDiff;
+        if (angleDiff > viewAngleWidth / 2) return;
+
+        const featureBaseX_m = planet.radius_m * Math.sin(feature.angle);
+        const featureBaseY_m = planet.radius_m * Math.cos(feature.angle);
+        const viewX_px = (featureBaseX_m - camX_m) * ppm;
+        const viewY_px = (featureBaseY_m - camY_m) * ppm;
+        const screenX_px = viewCenterX_px + viewX_px;
+        const screenY_px = viewCenterY_px - viewY_px; // Correct for Y-down
+
+        const height_px = feature.height_m * ppm;
+        const base_px = feature.baseWidth_m * ppm;
+
+        if (height_px < 0.5 && base_px < 0.5) return;
+
+        const featureGraphic = new PIXI.Graphics();
+        const colorData = parseRgba(feature.color); // Assumes parseRgba handles rgb()
+        const hexColor = (colorData.r << 16) + (colorData.g << 8) + colorData.b;
+        featureGraphic.beginFill(hexColor, colorData.alpha);
+
+        if (feature.type === 'mountain') {
+            if (base_px > 0.5 && height_px > 0.5) {
+                // Draw polygon relative to (0,0) before positioning and rotating
+                featureGraphic.moveTo(0, 0); // Tip of the mountain at the planet surface point
+                featureGraphic.lineTo(-base_px / 2, -height_px); // Bottom-left
+                featureGraphic.lineTo(base_px / 2, -height_px);  // Bottom-right
+                featureGraphic.closePath();
+            }
+        } else { // tree
+            if (base_px > 0.2 && height_px > 0.5) {
+                const trunkHeight_px = height_px * 0.4;
+                const foliageRadius_px = height_px * 0.6;
+                // Trunk - draw relative to (0,0) which is base of trunk center
+                featureGraphic.drawRect(-base_px / 2, -trunkHeight_px, base_px, trunkHeight_px);
+                // Foliage - draw relative to (0,0) which is base of trunk center
+                featureGraphic.drawCircle(0, -trunkHeight_px - foliageRadius_px * 0.6, foliageRadius_px);
+            }
+        }
+        featureGraphic.endFill();
+        
+        // Apply transformations
+        featureGraphic.x = screenX_px;
+        featureGraphic.y = screenY_px;
+        featureGraphic.rotation = feature.angle; // Rotate around the planet surface point
+
+        container.addChild(featureGraphic);
+    });
 }
 
 export function drawOrbitPath(mainCtx, camX_m, camY_m, ppm, spacecraftRef, apoapsisAGL, periapsisAGL) { 
     if (!spacecraftRef || spacecraftRef.altitudeAGL_m < ORBIT_PATH_VISIBILITY_ALTITUDE_M && ppm > ORBIT_PATH_VISIBILITY_PPM) return;  
-    if (apoapsisAGL === Infinity || isNaN(apoapsisAGL) || isNaN(periapsisAGL) || spacecraftRef.totalMass_kg <=0) return;  
-    const mu = GRAVITATIONAL_CONSTANT_G * planet.mass_kg; 
-    const r_vec_x = spacecraftRef.position_x_m; const r_vec_y = spacecraftRef.position_y_m; 
-    const v_vec_x = spacecraftRef.velocity_x_ms; const v_vec_y = spacecraftRef.velocity_y_ms; 
-    const r_mag = Math.sqrt(r_vec_x**2 + r_vec_y**2); 
-    const v_mag_sq = v_vec_x**2 + v_vec_y**2; 
-    const specificOrbitalEnergy = v_mag_sq / 2 - mu / r_mag; 
-    if (specificOrbitalEnergy >= 0) return;  
-    const h_vec_z = r_vec_x * v_vec_y - r_vec_y * v_vec_x;  
-    const eccentricity_vec_x = (v_mag_sq - mu / r_mag) * r_vec_x / mu - (r_vec_x * v_vec_x + r_vec_y * v_vec_y) * v_vec_x / mu; 
-    const eccentricity_vec_y = (v_mag_sq - mu / r_mag) * r_vec_y / mu - (r_vec_x * v_vec_x + r_vec_y * v_vec_y) * v_vec_y / mu; 
-    const eccentricity = Math.sqrt(eccentricity_vec_x**2 + eccentricity_vec_y**2); 
-    if (eccentricity >= 1) return;  
-    const semiMajorAxis = -mu / (2 * specificOrbitalEnergy); 
-    const argOfPeriapsis_rad = Math.atan2(eccentricity_vec_y, eccentricity_vec_x); 
-    mainCtx.strokeStyle = 'rgba(150, 150, 255, 0.5)'; 
-    mainCtx.lineWidth = Math.max(1, 1 / ppm * 0.00001); 
-    mainCtx.beginPath(); 
-    for (let i = 0; i <= ORBIT_PATH_SEGMENTS; i++) { 
-        const trueAnomaly_rad = (i / ORBIT_PATH_SEGMENTS) * 2 * Math.PI; 
-        const r_path = semiMajorAxis * (1 - eccentricity**2) / (1 + eccentricity * Math.cos(trueAnomaly_rad)); 
-        const x_perifocal = r_path * Math.cos(trueAnomaly_rad); 
-        const y_perifocal = r_path * Math.sin(trueAnomaly_rad); 
-        const x_world = x_perifocal * Math.cos(argOfPeriapsis_rad) - y_perifocal * Math.sin(argOfPeriapsis_rad); 
-        const y_world = x_perifocal * Math.sin(argOfPeriapsis_rad) + y_perifocal * Math.cos(argOfPeriapsis_rad); 
-        const viewX_px = (x_world - camX_m) * ppm; 
-        const viewY_px = (y_world - camY_m) * ppm; 
-        const screenX_px = mainCtx.canvas.width / 2 + viewX_px; 
-        const screenY_px = mainCtx.canvas.height / 2 - viewY_px; 
-        if (i === 0) mainCtx.moveTo(screenX_px, screenY_px); 
-        else mainCtx.lineTo(screenX_px, screenY_px); 
-    } 
-    mainCtx.stroke(); 
-    mainCtx.lineWidth = 1;  
+    if (apoapsisAGL === Infinity || isNaN(apoapsisAGL) || isNaN(periapsisAGL) || spacecraftRef.totalMass_kg <=0) return;
+    const mu = GRAVITATIONAL_CONSTANT_G * planet.mass_kg;
+    const r_vec_x = spacecraftRef.position_x_m; const r_vec_y = spacecraftRef.position_y_m;
+    const v_vec_x = spacecraftRef.velocity_x_ms; const v_vec_y = spacecraftRef.velocity_y_ms;
+    const r_mag = Math.sqrt(r_vec_x**2 + r_vec_y**2);
+    const v_mag_sq = v_vec_x**2 + v_vec_y**2;
+    const specificOrbitalEnergy = v_mag_sq / 2 - mu / r_mag;
+    if (specificOrbitalEnergy >= 0) return;
+    const h_vec_z = r_vec_x * v_vec_y - r_vec_y * v_vec_x;
+    const eccentricity_vec_x = (v_mag_sq - mu / r_mag) * r_vec_x / mu - (r_vec_x * v_vec_x + r_vec_y * v_vec_y) * v_vec_x / mu;
+    const eccentricity_vec_y = (v_mag_sq - mu / r_mag) * r_vec_y / mu - (r_vec_x * v_vec_x + r_vec_y * v_vec_y) * v_vec_y / mu;
+    const eccentricity = Math.sqrt(eccentricity_vec_x**2 + eccentricity_vec_y**2);
+    if (eccentricity >= 1) return;
+    const semiMajorAxis = -mu / (2 * specificOrbitalEnergy);
+    const argOfPeriapsis_rad = Math.atan2(eccentricity_vec_y, eccentricity_vec_x);
+
+    const orbitPathGraphic = new PIXI.Graphics();
+    const pathColorData = parseRgba('rgba(150, 150, 255, 0.5)');
+    const pathHexColor = (pathColorData.r << 16) + (pathColorData.g << 8) + pathColorData.b;
+    const lineWidth = Math.max(1, 1 / ppm * 0.00001); // This might become very small for Pixi lineStyle
+
+    orbitPathGraphic.lineStyle(lineWidth, pathHexColor, pathColorData.alpha);
+
+    const canvasWidth = container.parent.view.width;
+    const canvasHeight = container.parent.view.height;
+    const viewCenterX_px = canvasWidth / 2;
+    const viewCenterY_px = canvasHeight / 2;
+
+    for (let i = 0; i <= ORBIT_PATH_SEGMENTS; i++) {
+        const trueAnomaly_rad = (i / ORBIT_PATH_SEGMENTS) * 2 * Math.PI;
+        const r_path = semiMajorAxis * (1 - eccentricity**2) / (1 + eccentricity * Math.cos(trueAnomaly_rad));
+        const x_perifocal = r_path * Math.cos(trueAnomaly_rad);
+        const y_perifocal = r_path * Math.sin(trueAnomaly_rad);
+        const x_world = x_perifocal * Math.cos(argOfPeriapsis_rad) - y_perifocal * Math.sin(argOfPeriapsis_rad);
+        const y_world = x_perifocal * Math.sin(argOfPeriapsis_rad) + y_perifocal * Math.cos(argOfPeriapsis_rad);
+        const viewX_px = (x_world - camX_m) * ppm;
+        const viewY_px = (y_world - camY_m) * ppm;
+        const screenX_px = viewCenterX_px + viewX_px;
+        const screenY_px = viewCenterY_px - viewY_px; // Correct for Y-down
+
+        if (i === 0) orbitPathGraphic.moveTo(screenX_px, screenY_px);
+        else orbitPathGraphic.lineTo(screenX_px, screenY_px);
+    }
+    // No stroke() needed, lineTo builds the path for lineStyle
+    container.addChild(orbitPathGraphic);
 }
 
+// Helper function to parse rgba string
+function parseRgba(rgbaString) {
+    const match = rgbaString.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/);
+    if (!match) throw new Error('Invalid rgba string: ' + rgbaString); // Added error context
+    return {
+        r: parseInt(match[1]),
+        g: parseInt(match[2]),
+        b: parseInt(match[3]),
+        alpha: match[4] !== undefined ? parseFloat(match[4]) : 1
+    };
+}
 
-export function drawPlanet(mainCtx, camX_m, camY_m, ppm) { 
-    const viewCenterX_px = mainCtx.canvas.width / 2; 
-    const viewCenterY_px = mainCtx.canvas.height / 2;
+export function drawPlanet(container, camX_m, camY_m, ppm) { 
+    const canvasWidth = container.parent.view.width; 
+    const canvasHeight = container.parent.view.height;
+    const viewCenterX_px = canvasWidth / 2; 
+    const viewCenterY_px = canvasHeight / 2;
     const planetViewX_px = (0 - camX_m) * ppm;
-    const planetViewY_px = (0 - camY_m) * ppm;
+    const planetViewY_px = (0 - camY_m) * ppm; // PixiJS Y is down, so this might need adjustment if camY_m is Y-up. Assuming camY_m is world Y-up.
+    
+    // Screen X, Y for the center of the planet
     const planetScreenX_px = viewCenterX_px + planetViewX_px; 
-    const planetScreenY_px = viewCenterY_px - planetViewY_px; 
+    const planetScreenY_px = viewCenterY_px - planetViewY_px; // Correcting for Pixi's Y-down system.
+    
     const planetRadius_px = planet.radius_m * ppm;
-    //document.getElementById('gameCanvas');
-    let planetSVG = SVG('#planetEarthSVG');
 
-   // SVG.on(document, 'DOMContentLoaded', function() {
-    // if (!planetSVG) {
-    //     planetSVG = SVG().addTo('#gameCanvas').size('100%', '100%'); // Create a new SVG element if it doesn't exist
-    //     planetSVG.id = 'planetEarthSVG'; // Ensure the SVG has an ID for future reference
-    //     gameCanvasSVG.add(planetSVG);
-    // }
-    planetSVG.clear(); // Clear previous drawings
-    planetSVG.size(mainCtx.canvas.width, mainCtx.canvas.height); // Ensure SVG scales to canvas size
-    //planetSVG.scale(1 / ppm); // Scale the SVG to match the canvas PPM
-    planetSVG.circle(planetRadius_px*2)
-               // .move(planetScreenX_px, planetScreenY_px)
-                .fill('#f06');
-   // planetSVG.find(".continent").each({y=> y.scale(planetRadius_px*2/100.0).move(planetScreenX_px, planetScreenY_px).fill("#2ecc71");
+    // Draw Atmosphere
     if (planet.maxAtmosphereRadius_m * ppm > 2) { 
-         const atmRadius_px = planet.maxAtmosphereRadius_m * ppm;
-         mainCtx.fillStyle = planet.atmosphereColor; 
-         mainCtx.beginPath();
-         mainCtx.arc(planetScreenX_px, planetScreenY_px, atmRadius_px, 0, 2 * Math.PI); 
-         mainCtx.fill();
-    }
-    if (planetRadius_px > 0.5) { 
-        var planet = planetSVG.circle(planetRadius_px, x= viewCenterX_px, y = viewCenterY_px).fill(planet.color);
-      // planet.fillStyle = planet.color; 
-        //mainCtx.beginPath();
-        //mainCtx.arc(planetScreenX_px, planetScreenY_px, planetRadius_px, 0, 2 * Math.PI); 
-        //mainCtx.fill();
+        const atmRadius_px = planet.maxAtmosphereRadius_m * ppm;
+        const atmColorData = parseRgba(planet.atmosphereColor);
+        const atmHexColor = (atmColorData.r << 16) + (atmColorData.g << 8) + atmColorData.b;
         
+        const atmosphereGraphic = new PIXI.Graphics();
+        atmosphereGraphic.beginFill(atmHexColor, atmColorData.alpha);
+        atmosphereGraphic.drawCircle(0, 0, atmRadius_px); // Draw at origin, then position
+        atmosphereGraphic.endFill();
+        atmosphereGraphic.x = planetScreenX_px;
+        atmosphereGraphic.y = planetScreenY_px;
+        container.addChild(atmosphereGraphic);
+    }
+
+    // Draw Planet Body
+    if (planetRadius_px > 0.5) { 
+        // Assuming planet.color is a hex string like '#RRGGBB'
+        const planetHexColor = parseInt(planet.color.substring(1), 16);
+        
+        const planetGraphic = new PIXI.Graphics();
+        planetGraphic.beginFill(planetHexColor);
+        planetGraphic.drawCircle(0, 0, planetRadius_px); // Draw at origin, then position
+        planetGraphic.endFill();
+        planetGraphic.x = planetScreenX_px;
+        planetGraphic.y = planetScreenY_px;
+        container.addChild(planetGraphic);
     }
 }
 
-export function drawSkyBackground(mainCtx, spacecraftAltitudeAGL, canvasWidth, canvasHeight) {
+export function drawSkyBackground(container, spacecraftAltitudeAGL, canvasWidth, canvasHeight) {
     const atmFactor = spacecraftAltitudeAGL !== null ? Math.max(0, 1 - Math.min(1, spacecraftAltitudeAGL / EARTH_MAX_ATMOSPHERE_ALTITUDE)) : 1;
     const skyR = SPACE_BLACK_COLOR.r + (SKY_BLUE_COLOR.r - SPACE_BLACK_COLOR.r) * atmFactor;
     const skyG = SPACE_BLACK_COLOR.g + (SKY_BLUE_COLOR.g - SPACE_BLACK_COLOR.g) * atmFactor;
     const skyB = SPACE_BLACK_COLOR.b + (SKY_BLUE_COLOR.b - SPACE_BLACK_COLOR.b) * atmFactor;
-    mainCtx.fillStyle = `rgb(${Math.round(skyR)},${Math.round(skyG)},${Math.round(skyB)})`; 
-    mainCtx.fillRect(0, 0, canvasWidth, canvasHeight); 
+    
+    const skyColor = (Math.round(skyR) << 16) + (Math.round(skyG) << 8) + Math.round(skyB);
+    
+    const skyRect = new PIXI.Graphics();
+    skyRect.beginFill(skyColor);
+    skyRect.drawRect(0, 0, canvasWidth, canvasHeight);
+    skyRect.endFill();
+    container.addChild(skyRect);
 }

--- a/index.html
+++ b/index.html
@@ -6,13 +6,10 @@
     <title>2D Spacecraft Prototype - V9.0 (Modular)</title>
     <link rel="stylesheet" href="style.css"> <!-- We'll move CSS to a separate file -->
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/svg.js/3.2.4/svg.min.js" integrity="sha512-ovlWyhrYXr3HEkGJI5YPXIFYIbHEKs2yfemKVVIIQe9U74tXyTuVdzMlvZlw/0X5lnIDRgtVlckrkeuCrDpq4Q==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-   
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/svg.js/3.2.4/svg.draggable.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/svg.js/3.2.4/svg.panzoom.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/7.2.4/pixi.min.js"></script>
 </head>
 <body>
-    <div id="dragImage"></div> 
+    <div id="dragImage"></div>
     <div id="pageContainer">
         <h1>2D Spacecraft - Modular (V9.0)</h1>
         
@@ -52,14 +49,7 @@
 
             <div id="leftPanel">
                 <div id="mainContainer">
-                    <canvas id="gameCanvas">
-                    <svg width="200" height="200" id="planetEarthSVG" xmlns="http://www.w3.org/2000/svg"><g>
-                        <circle class="globe" cx="100" cy="100" r="100" fill="#3498db" stroke="#2c3e50" stroke-width="5"/>
-                        <path class="continent" d="M60,80 Q80,50 100,80 T140,80 T160,100 T120,140 Q100,170 80,140 T60,100" fill="#2ecc71"/>
-                        <path class="continent" d="M90,60 Q110,40 130,60 T140,100 Q130,120 110,100 T90,60" fill="#2ecc71"/>
-</g></svg>
-</canvas>
-
+                    <canvas id="gameCanvas"></canvas>
                     <canvas id="insetCanvas"></canvas>
                     <div id="uiOverlay">
                         <div id="stats" style="display:none;">


### PR DESCRIPTION
This commit completes the migration of the application's rendering engine from the HTML5 Canvas 2D API to PixiJS.

Key changes include:

- Replaced direct canvas context drawing with PixiJS objects (PIXI.Graphics, PIXI.Container).
- Initialized a main PixiJS application and specific PIXI.Applications for staging and inset views.
- Migrated rendering for:
    - Environment (sky, planet, clouds, surface features, orbit paths)
    - Spacecraft (parts, engine flames)
    - Smoke particles
    - Staging area preview
    - Inset view
- Addressed initial issues found after migration:
    - Corrected smoke particle layering to ensure it renders behind the spacecraft.
    - Optimized smoke particle rendering by creating PIXI.Graphics objects once per particle instead of per frame, significantly improving performance.
- Organized rendering into separate layers/containers for better scene management.

The application should now benefit from PixiJS's WebGL-accelerated rendering, leading to improved performance and a more robust rendering foundation.